### PR TITLE
Fix PostCSS config: cssnano added to the package, minimize css output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/node_modules
-/dist
+**/node_modules
+**/dist
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yp_mesto",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,8 +2,7 @@ module.exports = {
   plugins: [
     require("autoprefixer"),
     require("cssnano")({
-      // подключили cssnano
-      preset: "default" // выбрали настройки по умолчанию
+      preset: "default"
     })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const WebpackMd5Hash = require("webpack-md5-hash");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin"); // добавили плагин
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = {
   entry: { main: "./src/index.js" },
   output: {
@@ -20,7 +20,21 @@ module.exports = {
 
       {
         test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, "css-loader", "postcss-loader"]
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader",
+            options: {
+              importLoaders: 1
+            }
+          },
+          {
+            loader: "postcss-loader"
+          }
+        ]
       },
       {
         test: /\.(eot|ttf|woff|woff2)$/,


### PR DESCRIPTION
Fixed the PostCSS config by adding cssnano plugin to the package. Webpack now minimizes the css output.
Updated .gitignore.